### PR TITLE
:bookmark: bump version 0.2.0 -> 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.2.1]
+
 ### Changed
 
 - Simplified signal handling in `@async_receiver` decorator by removing redundant iterable checking, as `django.dispatch.receiver` already handles multiple signals internally.
@@ -41,6 +43,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-q-signals/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-q-signals/compare/v0.2.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-q-signals/releases/tag/v0.1.0
 [0.2.0]: https://github.com/joshuadavidthomas/django-q-signals/releases/tag/v0.2.0
+[0.2.1]: https://github.com/joshuadavidthomas/django-q-signals/releases/tag/v0.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ readme = "README.md"
 # ]]] -->
 requires-python = ">=3.10"
 # [[[end]]]
-version = "0.2.0"
+version = "0.2.1"
 
 [project.urls]
 Documentation = "https://github.com/joshuadavidthomas/django-q-signals#README"
@@ -91,7 +91,7 @@ Source = "https://github.com/joshuadavidthomas/django-q-signals"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.2.0"
+current_version = "0.2.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"


### PR DESCRIPTION
- `afedace`: Remove redundant signal iterable handling in `async_receiver` (#5)
- `2547981`: downgrade helper scripts to align with project python version